### PR TITLE
modify logic for loading empty scene

### DIFF
--- a/mujoco_scenes/mjcf.py
+++ b/mujoco_scenes/mjcf.py
@@ -182,20 +182,21 @@ def load_mjmodel(path: str | epath.Path, scene: str | None = None) -> mujoco.MjM
     meshdir = _get_meshdir(elem)
     assets = _find_assets(elem, epath.Path(path), meshdir)
     xml = ET.tostring(elem, encoding="unicode")
-    mj = mujoco.MjModel.from_xml_string(xml, assets=assets)
+    
+    if scene is None:
+        mj = mujoco.MjModel.from_xml_string(xml, assets=assets)
+        return mj
 
-    # Loads the scene, if provided.
-    if scene is not None:
-        scene_path = get_scene(scene)
-        scene_text = scene_path.read_text()
-        if (robot_match := re.search(r"<mujoco model=\"(.*)\"", xml)) is None:
-            robot_name = "robot"
-        else:
-            robot_name = robot_match.group(1)
-        scene_text = scene_text.format(name=robot_name, path=path)
-        scene_elem = ET.fromstring(scene_text)
-        assets.update(_find_assets(scene_elem, scene_path, meshdir))
-        scene_xml = ET.tostring(scene_elem, encoding="unicode")
-        mj = mujoco.MjModel.from_xml_string(scene_xml, assets=assets)
-
+    scene_path = get_scene(scene)
+    scene_text = scene_path.read_text()
+    if (robot_match := re.search(r"<mujoco model=\"(.*)\"", xml)) is None:
+        robot_name = "robot"
+    else:
+        robot_name = robot_match.group(1)
+    scene_text = scene_text.format(name=robot_name, path=path)
+    scene_elem = ET.fromstring(scene_text)
+    assets.update(_find_assets(scene_elem, scene_path, meshdir))
+    scene_xml = ET.tostring(scene_elem, encoding="unicode")
+    mj = mujoco.MjModel.from_xml_string(scene_xml, assets=assets)
+    
     return mj

--- a/mujoco_scenes/mjcf.py
+++ b/mujoco_scenes/mjcf.py
@@ -182,7 +182,7 @@ def load_mjmodel(path: str | epath.Path, scene: str | None = None) -> mujoco.MjM
     meshdir = _get_meshdir(elem)
     assets = _find_assets(elem, epath.Path(path), meshdir)
     xml = ET.tostring(elem, encoding="unicode")
-    
+
     if scene is None:
         mj = mujoco.MjModel.from_xml_string(xml, assets=assets)
         return mj
@@ -198,5 +198,5 @@ def load_mjmodel(path: str | epath.Path, scene: str | None = None) -> mujoco.MjM
     assets.update(_find_assets(scene_elem, scene_path, meshdir))
     scene_xml = ET.tostring(scene_elem, encoding="unicode")
     mj = mujoco.MjModel.from_xml_string(scene_xml, assets=assets)
-    
+
     return mj


### PR DESCRIPTION
The old logic breaks if there is an explicit contact list with the floor which we now have. 

This is because the old code tries to load just the model first regardless of if scene is None, which causes 
```
  Traceback (most recent call last):
    File "/path/to/ksim/ksim/task/rl.py", line 720, in run_training
      self.rl_train_loop(
    File "/path/to/ksim/ksim/task/rl.py", line 543, in rl_train_loop
      physics_model, metadata = self.get_model_and_metadata()
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/path/to/ksim/examples/kbot2/standing.py", line 201, in get_model_and_metadata
      mj_model = load_mjmodel("/path/to/ksim/examples/kscale-assets/kbot-v2-feet/robot.mjcf", "smooth")
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "mujoco-scenes/mujoco_scenes/mjcf.py", line 185, in load_mjmodel
      mj = mujoco.MjModel.from_xml_string(xml, assets=assets)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ValueError: Error: geom 'floor' not found in collision 0
  Element name '', id 0, line 213
  ```
  
So I am modifying the logic so that "just the model" is only loaded iff scene is None, otherwise it formats the scene with the model so that the floor is found in the contacts list. 